### PR TITLE
Move `Footer` to markdown for easy customization

### DIFF
--- a/packages/gatsby-theme-jamstack-meetup/src/components/Footer/Footer.component.js
+++ b/packages/gatsby-theme-jamstack-meetup/src/components/Footer/Footer.component.js
@@ -1,29 +1,25 @@
 import React from 'react'
+import { StaticQuery, graphql } from 'gatsby'
+
 import StyledFooter from './Footer.style'
 
-const Footer = ({ siteTitle }) => (
-  <div>
-    <StyledFooter>
-      <p>
-        Meetup organisé avec{' '}
-        <span role="img" aria-label="cœur">
-          ❤️
-        </span>
-        par <a href="https://twitter.com/matthieuauger">Matthieu Auger</a> et{' '}
-        <a href="https://twitter.com/phacks">Nicolas Goutay</a>.
-      </p>
-      <br />
-      <p>
-        Site construit avec <a href="https://gatsbyjs.org">GatsbyJS</a>,{' '}
-        <a href="https://contentful.com">Contentful</a> et{' '}
-        <a href="https://netlify.com">Netlify</a>.
-      </p>
-      <p>
-        Voir le code source sur{' '}
-        <a href="https://github.com/jamstack-paris/jamstack.paris">GitHub</a>.
-      </p>
-    </StyledFooter>
-  </div>
+const Footer = () => (
+  <StaticQuery
+    query={graphql`
+      query FooterQuery {
+        footerContent: markdownRemark(frontmatter: { type: { eq: "footer" } }) {
+          html
+        }
+      }
+    `}
+    render={data => (
+      <StyledFooter
+        dangerouslySetInnerHTML={{
+          __html: data.footerContent.html,
+        }}
+      ></StyledFooter>
+    )}
+  />
 )
 
 export default Footer

--- a/packages/gatsby-theme-jamstack-meetup/src/text-blocks/footer.md
+++ b/packages/gatsby-theme-jamstack-meetup/src/text-blocks/footer.md
@@ -1,0 +1,11 @@
+---
+type: 'footer'
+---
+
+Meetup organized with ️️❤️ by [Phil Hawksworth](https://twitter.com/philhawksworth).
+
+<br />
+
+This site is buit with [GatsbyJS](https://gatsbyjs.org), [Gatsby Theme Meetup](https://github.com/matthieuauger/gatsby-theme-meetup) and [Netlify](https://netlify.com).
+
+See the source code on [GitHub](https://github.com/jamstack-paris/jamstack.paris).

--- a/site/src/text-blocks/footer.md
+++ b/site/src/text-blocks/footer.md
@@ -1,0 +1,11 @@
+---
+type: 'footer'
+---
+
+Meetup organisé avec ️️❤️ par [Matthieu Auger](https://twitter.com/matthieuauger) et [Nicolas Goutay](https://twitter.com/phacks).
+
+<br />
+
+Site construit avec [GatsbyJS](https://gatsbyjs.org), [Gatsby Theme Meetup](https://github.com/matthieuauger/gatsby-theme-meetup) et [Netlify](https://netlify.com).
+
+Voir le code source sur [GitHub](https://github.com/jamstack-paris/jamstack.paris).


### PR DESCRIPTION
Move the `Footer` component to be markdown-based for easy customization