### PR TITLE
update README to add Meetup API key to environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ You can get a new Meetup Gatsby site up and running on your local dev environmen
      ]
    };
    ```
+3. **Set API key**
+
+   Add `MEETUP_API_KEY` env variable from here: https://secure.meetup.com/meetup_api/key/
 
 4. **Start the site in `develop` mode.**
 


### PR DESCRIPTION
In order to get this product running without null data errors I needed to create an environment variable with my Meetup API key. Meetup is moving away from API keys so I am not sure if the underlying plugin is going to be updated to address that. 

On the Meetup API site it says:
> Note: We are no longer supporting new API keys, and will soon be restricting access using your existing key. As an alternative, you can use OAuth2. Learn more.